### PR TITLE
Use flake input to track upstream K repository

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,6 +31,22 @@
         "type": "github"
       }
     },
+    "k-git": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644358111,
+        "narHash": "sha256-wN1C1xP2SkWvhYBLGPO3zthj3b1zESW9TOpVvQbPMHI=",
+        "ref": "master",
+        "rev": "ba2c2bab7e533e8fdc4e4cc2ee0c0c939990d5f5",
+        "revCount": 3079,
+        "type": "git",
+        "url": "https://codeberg.org/ngn/k.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://codeberg.org/ngn/k.git"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1644420267,
@@ -51,6 +67,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
+        "k-git": "k-git",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -5,11 +5,12 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
+    k-git = { url = "git+https://codeberg.org/ngn/k.git"; flake = false; };
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
+  outputs = { self, nixpkgs, flake-utils, k-git, ... }:
     {
-      overlay = final: prev: { k = final.callPackage ./k {}; };
+      overlay = final: prev: { k = final.callPackage ./k { inherit k-git; }; };
     } //
     flake-utils.lib.eachDefaultSystem (system:
       let

--- a/k/default.nix
+++ b/k/default.nix
@@ -1,14 +1,10 @@
-{ stdenv, fetchurl, clang_12, rlwrap }:
+{ stdenv, fetchurl, clang_12, rlwrap, k-git }:
 
 stdenv.mkDerivation rec {
   pname = "k";
-  version = "unstable-2022_02_09";
-  rev = "440a8ea492fdf94cc1ba3736fdbe6b34c487f122";
-
-  src = fetchurl {
-    url = "https://codeberg.org/ngn/k/archive/${rev}.tar.gz";
-    hash = "sha256-Eel9ZTlpJrfW/LJSK25Q+D2WiAuDUJqE6sFzVN7t2bw=";
-  };
+  version = "unstable-${k-git.lastModifiedDate}";
+  rev = k-git.rev;
+  src = k-git;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
This allows for easy editing via `nix flake lock --update-input`.