### PR TITLE
Print build logs during `nix build`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       with:
         name: nathyong
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix build
+    - run: nix build --print-build-logs


### PR DESCRIPTION
Can't believe this isn't the default?