### PR TITLE
Build k by default

### DIFF
--- a/k/default.nix
+++ b/k/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ clang_12 ];
 
-  makeFlags = [ "k" "CC=clang" ];
+  makeFlags = [ "k-dflt" "CC=clang" ];
 
   prePatch = ''
     patchShebangs .

--- a/k/default.nix
+++ b/k/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ clang_12 ];
 
-  makeFlags = [ "k-libc" "CC=clang" ];
+  makeFlags = [ "k" "CC=clang" ];
 
   prePatch = ''
     patchShebangs .


### PR DESCRIPTION
k-libc longer necessary as of https://codeberg.org/ngn/k/commit/543825e5e6e5b1ccfa2f8fec4cf9a926c1f0dfa3